### PR TITLE
Remove pkgConfig to enable usage on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
     targets: [
         .systemLibrary(
             name: "CSQLite",
-            pkgConfig: "sqlite3",
             providers: [
                 .apt(["sqlite3"]),
                 .brew(["sqlite3"])


### PR DESCRIPTION
This has no impact on macOS or Linux deployments, and enables usage of this library on iOS devices. This is good for if folks want to use `fluent-kit` + `sqlite-fluent-driver` in their iOS apps.