### PR TITLE
Fix apt provider package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .systemLibrary(
             name: "CSQLite",
             providers: [
-                .apt(["sqlite3"]),
+                .apt(["libsqlite3-dev"]),
                 .brew(["sqlite3"])
             ]
         ),


### PR DESCRIPTION
Even though this part is only meant as information, this should be fixed, because it might be misleading. The package [sqlite3 is only the command line interface](https://packages.ubuntu.com/xenial/sqlite3) and in the `circle.yml` it's `libsqlite3-dev` as well.