### PR TITLE
Fix Reference Date

### DIFF
--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -119,3 +119,16 @@ extension Bool: SQLiteDataConvertible {
         return .integer(self ? 1 : 0)
     }
 }
+
+extension Date: SQLiteDataConvertible {
+    public init?(sqliteData: SQLiteData) {
+        guard case .float(let value) = sqliteData else {
+            return nil
+        }
+        self.init(timeIntervalSince1970: value)
+    }
+
+    public var sqliteData: SQLiteData? {
+        return .float(timeIntervalSince1970)
+    }
+}

--- a/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
+++ b/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
@@ -25,6 +25,7 @@ final class SQLiteNIOTests: XCTestCase {
         let date = Date()
         let rows = try conn.query("SELECT ? as date", [date.sqliteData!]).wait()
         XCTAssertEqual(rows[0].column("date"), .float(date.timeIntervalSince1970))
+        XCTAssertEqual(Date(sqliteData: rows[0].column("date")!)?.description, date.description)
     }
 
     var threadPool: NIOThreadPool!

--- a/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
+++ b/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
@@ -9,12 +9,22 @@ final class SQLiteNIOTests: XCTestCase {
         let rows = try conn.query("SELECT sqlite_version()").wait()
         print(rows)
     }
+
     func testZeroLengthBlob() throws {
         let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
         defer { try! conn.close().wait() }
 
         let rows = try conn.query("SELECT zeroblob(0) as zblob").wait()
         print(rows)
+    }
+
+    func testTimestampStorage() throws {
+        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+
+        let date = Date()
+        let rows = try conn.query("SELECT ? as date", [date.sqliteData!]).wait()
+        XCTAssertEqual(rows[0].column("date"), .float(date.timeIntervalSince1970))
     }
 
     var threadPool: NIOThreadPool!


### PR DESCRIPTION
`Date` was inadvertently storing `secondsSinceReferenceDate` values in the database. This should use `secondsSince1970` to match Vapor 3's behavior and use a more sensible value. 