### PR TITLE
Support Decoding Swift.Date from DATE

### DIFF
--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -122,10 +122,14 @@ extension Bool: SQLiteDataConvertible {
 
 extension Date: SQLiteDataConvertible {
     public init?(sqliteData: SQLiteData) {
-        guard case .float(let value) = sqliteData else {
+        switch sqliteData {
+        case .integer(let value):
+            self.init(timeIntervalSince1970: Double(value))
+        case .float(let value):
+            self.init(timeIntervalSince1970: value)
+        default:
             return nil
         }
-        self.init(timeIntervalSince1970: value)
     }
 
     public var sqliteData: SQLiteData? {

--- a/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
+++ b/Tests/SQLiteNIOTests/NIOSQLiteTests.swift
@@ -28,6 +28,16 @@ final class SQLiteNIOTests: XCTestCase {
         XCTAssertEqual(Date(sqliteData: rows[0].column("date")!)?.description, date.description)
     }
 
+    func testDateStorage() throws {
+        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+
+        _ = try conn.query("CREATE TABLE foo (bar DATE)").wait()
+        _ = try conn.query("INSERT INTO foo (bar) VALUES (strftime('%s','2020-01-02'))").wait()
+        let rows = try conn.query("SELECT bar FROM foo").wait()
+        XCTAssertEqual(Date(sqliteData: rows[0].column("bar")!)?.description, "2020-01-02 00:00:00 +0000")
+    }
+
     var threadPool: NIOThreadPool!
     var eventLoopGroup: EventLoopGroup!
     var eventLoop: EventLoop {


### PR DESCRIPTION
Adds support for decoding a Swift `Date` from SQLite `DATE` type (which has [numeric affinity](https://www.sqlite.org/datatype3.html)) (#14). 

This works by allowing Swift `Date` to be decodable from the SQLite `INTEGER` column type which results from storage of Swift `Date` into the dynamic `NUMERIC` field type.

There is a chance for lossiness here since Swift `Date` stores sub-second time information in the fraction of a `Double` / `REAL` field. However, this should be fine for dates without time and this should only affect `NUMERIC` fields.