### PR TITLE
Remove macOS 10_15 iOS 13 platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,6 @@ import PackageDescription
 
 let package = Package(
     name: "sqlite-nio",
-    platforms: [
-       .macOS(.v10_15),
-       .iOS(.v13)
-    ],
     products: [
         .library(name: "SQLiteNIO", targets: ["SQLiteNIO"]),
     ],


### PR DESCRIPTION
This is not necessary and causes error in SQLiteKit:
The package product 'SQLiteNIO' requires minimum platform version 13.0 for the iOS platform, but this target supports 8.0