### PR TITLE
Add support for duplicate column names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,54 +1,92 @@
 name: test
 on:
-- pull_request
+  pull_request:
+  push:
+    branches:
+    - master
+defaults:
+  run:
+    shell: bash
 jobs:
-  sqlite-nio_bionic:
-    container: 
-      image: vapor/swift:5.2-bionic
+  dependents:
     runs-on: ubuntu-latest
+    container: swift:5.2-bionic
+    strategy:
+      fail-fast: false
+      matrix:
+        dependent:
+          - sqlite-kit
+          - fluent-sqlite-driver
     steps:
-    - run: apt update -y; apt install -y libsqlite3-dev
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  sqlite-nio_xenial:
-    container: 
-      image: vapor/swift:5.2-xenial
+      - name: Install dependencies
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+      - name: Check out SQLiteNIO
+        uses: actions/checkout@v2
+        with:
+          path: sqlite-nio
+      - name: Check out dependent
+        uses: actions/checkout@v2
+        with:
+          repository: vapor/${{ matrix.provider }}
+          path: dependent
+      - name: Use local SQLiteNIO
+        run: swift package edit sqlite-nio --path sqlite-nio
+        working-directory: provider
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread
+        working-directory: dependent
+  linux:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          # 5.2 Stable
+          - swift:5.2-xenial
+          - swift:5.2-bionic
+          # 5.2 Unstable
+          - swiftlang/swift:nightly-5.2-xenial
+          - swiftlang/swift:nightly-5.2-bionic
+          # 5.3 Unstable
+          - swiftlang/swift:nightly-5.3-xenial
+          - swiftlang/swift:nightly-5.3-bionic
+          # Master Unsable
+          - swiftlang/swift:nightly-master-xenial
+          - swiftlang/swift:nightly-master-bionic
+          - swiftlang/swift:nightly-master-focal
+          - swiftlang/swift:nightly-master-centos8
+          - swiftlang/swift:nightly-master-amazonlinux2
+    container: ${{ matrix.image }}
     steps:
-    - run: apt update -y; apt install -y libsqlite3-dev
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  # sqlite-nio_catalina:
-  #   runs-on: macOS-10.15
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - run: swift test --sanitize=thread
-  # sqlite-nio_ios13:
-  #   runs-on: macOS-10.15
-  #   steps:
-  #   - uses: actions/checkout@v1
-  #   - run: xcodebuild test -destination 'name=iPhone 11' -scheme 'sqlite-nio'
-  sqlite-kit:
-    container: 
-      image: vapor/swift:5.2
-    runs-on: ubuntu-latest
+      - name: Install Ubuntu dependencies
+        run: apt-get -q update && apt-get -q install -y libsqlite3-dev
+        if: ${{ endsWith(matrix.image, 'xenial') || endsWith(matrix.image, 'bionic') || endsWith(matrix.image, 'focal') }}
+      - name: Install CentOS deps
+        run: dnf install -y sqlite-devel
+        if: ${{ endsWith(matrix.image, 'centos8') }}
+      - name: Update AmazonLinux2's too-old SQLite and compensate for its Postgres
+        if: ${{ endsWith(matrix.image, 'amazonlinux2') }}
+        working-directory: /root
+        # Cribbed from the Fedora RPM, leaves out a lot. System's Tcl is too old to run SQLite's tests.
+        run: |
+          yum install -y sqlite-devel
+          yum install -y file tcl-devel make
+          curl -L 'https://www.sqlite.org/src/tarball/sqlite.tar.gz?r=release' | tar xz && cd sqlite
+          export CFLAGS="-DSQLITE_DISABLE_DIRSYNC=1 -DSQLITE_SECURE_DELETE=1"
+          ./configure --prefix=/usr --libdir=/usr/lib64 --enable-fts3 --enable-all --with-tcl=/usr/lib64
+          make all install
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread
+  macOS:
+    runs-on: macos-latest
     steps:
-    - run: apt update -y; apt install -y libsqlite3-dev
-    - run: git clone -b master https://github.com/vapor/sqlite-kit.git
-      working-directory: ./
-    - run: swift package edit sqlite-nio --revision ${{ github.sha }}
-      working-directory: ./sqlite-kit
-    - run: swift test --enable-test-discovery --sanitize=thread
-      working-directory: ./sqlite-kit
-  fluent-sqlite-driver:
-    container: 
-      image: vapor/swift:5.2
-    runs-on: ubuntu-latest
-    steps:
-    - run: apt update -y; apt install -y libsqlite3-dev
-    - run: git clone -b master https://github.com/vapor/fluent-sqlite-driver.git
-      working-directory: ./
-    - run: swift package edit sqlite-nio --revision ${{ github.sha }}
-      working-directory: ./fluent-sqlite-driver
-    - run: swift test --enable-test-discovery --sanitize=thread
-      working-directory: ./fluent-sqlite-driver
+      - name: Select latest available Xcode
+        uses: maxim-lobanov/setup-xcode@1.0
+        with:
+          xcode-version: latest
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run tests with Thread Sanitizer
+        run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out dependent
         uses: actions/checkout@v2
         with:
-          repository: vapor/${{ matrix.provider }}
+          repository: vapor/${{ matrix.dependent }}
           path: dependent
       - name: Use local SQLiteNIO
         run: swift package edit sqlite-nio --path sqlite-nio

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           path: dependent
       - name: Use local SQLiteNIO
         run: swift package edit sqlite-nio --path sqlite-nio
-        working-directory: provider
+        working-directory: dependent
       - name: Run tests with Thread Sanitizer
         run: swift test --enable-test-discovery --sanitize=thread
         working-directory: dependent

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 DerivedData
 .swiftpm
 Package.resolved
+Tests/LinuxMain.swift
 

--- a/Sources/SQLiteNIO/SQLiteData.swift
+++ b/Sources/SQLiteNIO/SQLiteData.swift
@@ -19,10 +19,36 @@ public enum SQLiteData: Equatable, Encodable, CustomStringConvertible {
         switch self {
         case .integer(let integer):
             return integer
-        case .float(let float):
-            return Int(float)
+        case .float(let double):
+            return Int(double)
         case .text(let string):
             return Int(string)
+        case .blob, .null:
+            return nil
+        }
+    }
+
+    public var double: Double? {
+        switch self {
+        case .integer(let integer):
+            return Double(integer)
+        case .float(let double):
+            return double
+        case .text(let string):
+            return Double(string)
+        case .blob, .null:
+            return nil
+        }
+    }
+
+    public var string: String? {
+        switch self {
+        case .integer(let integer):
+            return String(integer)
+        case .float(let double):
+            return String(double)
+        case .text(let string):
+            return string
         case .blob, .null:
             return nil
         }

--- a/Sources/SQLiteNIO/SQLiteData.swift
+++ b/Sources/SQLiteNIO/SQLiteData.swift
@@ -15,6 +15,19 @@ public enum SQLiteData: Equatable, Encodable, CustomStringConvertible {
     /// `NULL`.
     case null
 
+    public var integer: Int? {
+        switch self {
+        case .integer(let integer):
+            return integer
+        case .float(let float):
+            return Int(float)
+        case .text(let string):
+            return Int(string)
+        case .blob, .null:
+            return nil
+        }
+    }
+
     /// Description of data
     public var description: String {
         switch self {

--- a/Sources/SQLiteNIO/SQLiteRow.swift
+++ b/Sources/SQLiteNIO/SQLiteRow.swift
@@ -18,7 +18,7 @@ public struct SQLiteRow {
     }
 
     public func column(_ name: String) -> SQLiteData? {
-        guard let offset = self.columnOffsets.lookupTable[name]?.first else {
+        guard let offset = self.columnOffsets.lookupTable[name] else {
             return nil
         }
         return self.data[offset]
@@ -33,14 +33,10 @@ extension SQLiteRow: CustomStringConvertible {
 
 final class SQLiteColumnOffsets {
     let offsets: [(String, Int)]
-    let lookupTable: [String: [Int]]
+    let lookupTable: [String: Int]
 
     init(offsets: [(String, Int)]) {
         self.offsets = offsets
-        var lookupTable: [String: [Int]] = [:]
-        for (name, offset) in self.offsets {
-            lookupTable[name, default: []].append(offset)
-        }
-        self.lookupTable = lookupTable
+        self.lookupTable = .init(offsets, uniquingKeysWith: { a, b in a })
     }
 }

--- a/Sources/SQLiteNIO/SQLiteStatement.swift
+++ b/Sources/SQLiteNIO/SQLiteStatement.swift
@@ -50,8 +50,8 @@ internal struct SQLiteStatement {
         }
     }
 
-    internal func columns() throws -> SQLiteColumns {
-        var columns: [String: Int] = [:]
+    internal func columns() throws -> SQLiteColumnOffsets {
+        var columns: [(String, Int)] = []
 
         let count = sqlite3_column_count(self.handle)
         columns.reserveCapacity(Int(count))
@@ -59,13 +59,13 @@ internal struct SQLiteStatement {
         // iterate over column count and intialize columns once
         // we will then re-use the columns for each row
         for i in 0..<count {
-            try columns[self.column(at: i)] = numericCast(i)
+            try columns.append((self.column(at: i), numericCast(i)))
         }
 
         return .init(offsets: columns)
     }
 
-    internal func nextRow(for columns: SQLiteColumns) throws -> SQLiteRow? {
+    internal func nextRow(for columns: SQLiteColumnOffsets) throws -> SQLiteRow? {
         // step over the query, this will continue to return SQLITE_ROW
         // for as long as there are new rows to be fetched
         let step = sqlite3_step(self.handle)
@@ -89,7 +89,7 @@ internal struct SQLiteStatement {
         for i in 0..<count {
             try row.append(self.data(at: Int32(i)))
         }
-        return SQLiteRow(columns: columns, data: row)
+        return SQLiteRow(columnOffsets: columns, data: row)
     }
 
     // MARK: Private


### PR DESCRIPTION
Adds support for duplicate column names to `SQLiteRow` (#21, fixes #12). 

`SQLiteRow.columns` is now an array of columns instead of a dictionary. `SQLiteRow.column` uses a lookup table to keep `O(1)` performance. 