### PR TITLE
Improve SQLite Boolean decoding

### DIFF
--- a/Sources/SQLiteNIO/SQLiteData.swift
+++ b/Sources/SQLiteNIO/SQLiteData.swift
@@ -53,6 +53,14 @@ public enum SQLiteData: Equatable, Encodable, CustomStringConvertible {
             return nil
         }
     }
+    
+    public var bool: Bool? {
+       switch self.string {
+            case "1": return true
+            case "0": return false
+            default: return nil
+        }
+    }
 
     /// Description of data
     public var description: String {

--- a/Sources/SQLiteNIO/SQLiteData.swift
+++ b/Sources/SQLiteNIO/SQLiteData.swift
@@ -55,9 +55,9 @@ public enum SQLiteData: Equatable, Encodable, CustomStringConvertible {
     }
     
     public var bool: Bool? {
-       switch self.string {
-            case "1": return true
-            case "0": return false
+       switch self.integer {
+            case 1: return true
+            case 0: return false
             default: return nil
         }
     }

--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -102,16 +102,10 @@ extension Data: SQLiteDataConvertible {
 
 extension Bool: SQLiteDataConvertible {
     public init?(sqliteData: SQLiteData) {
-        guard case .integer(let value) = sqliteData else {
-            return nil
-        }
-        switch value {
-        case 1:
-            self = true
-        case 0:
-            self = false
-        default:
-            return nil
+        guard let bool = sqliteData.bool else {
+                return nil
+            }
+            self = bool
         }
     }
 

--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -107,7 +107,6 @@ extension Bool: SQLiteDataConvertible {
             }
             self = bool
         }
-    }
 
     public var sqliteData: SQLiteData? {
         return .text(self ? "1" : "0")

--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -109,7 +109,7 @@ extension Bool: SQLiteDataConvertible {
         }
 
     public var sqliteData: SQLiteData? {
-        return .text(self ? "1" : "0")
+        return .integer(self ? 1 : 0)
     }
 }
 

--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -110,7 +110,7 @@ extension Bool: SQLiteDataConvertible {
     }
 
     public var sqliteData: SQLiteData? {
-        return .integer(self ? 1 : 0)
+        return .text(self ? "1" : "0")
     }
 }
 

--- a/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
+++ b/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
@@ -42,20 +42,20 @@ final class SQLiteNIOTests: XCTestCase {
         XCTAssertEqual(Date(sqliteData: rows[0].column("date")!)?.description, date.description)
     }
 
-//    func testDuplicateColumnName() throws {
-//        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
-//        defer { try! conn.close().wait() }
-//
-//        let rows = try conn.query("SELECT 1 as foo, 2 as foo").wait()
-//        var i = 0
-//        for column in rows[0].columns {
-//            XCTAssertEqual(column.name, "foo")
-//            i += column.data.integer!
-//        }
-//        XCTAssertEqual(i, 3)
-//        XCTAssertEqual(rows[0].column("foo")?.integer, 1)
-//        XCTAssertEqual(rows[0].columns.filter { $0.name == "foo" }[1].data.integer, 2)
-//    }
+    func testDuplicateColumnName() throws {
+        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+
+        let rows = try conn.query("SELECT 1 as foo, 2 as foo").wait()
+        var i = 0
+        for column in rows[0].columns {
+            XCTAssertEqual(column.name, "foo")
+            i += column.data.integer!
+        }
+        XCTAssertEqual(i, 3)
+        XCTAssertEqual(rows[0].column("foo")?.integer, 1)
+        XCTAssertEqual(rows[0].columns.filter { $0.name == "foo" }[1].data.integer, 2)
+    }
 
     var threadPool: NIOThreadPool!
     var eventLoopGroup: EventLoopGroup!

--- a/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
+++ b/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
@@ -42,20 +42,20 @@ final class SQLiteNIOTests: XCTestCase {
         XCTAssertEqual(Date(sqliteData: rows[0].column("date")!)?.description, date.description)
     }
 
-    func testDuplicateColumnName() throws {
-        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
-        defer { try! conn.close().wait() }
-
-        let rows = try conn.query("SELECT 1 as foo, 2 as foo").wait()
-        var i = 0
-        for column in rows[0].columns {
-            XCTAssertEqual(column.name, "foo")
-            i += column.data.integer!
-        }
-        XCTAssertEqual(i, 3)
-        XCTAssertEqual(rows[0].column("foo")?.integer, 1)
-        XCTAssertEqual(rows[0].columns.filter { $0.name == "foo" }[1].data.integer, 2)
-    }
+//    func testDuplicateColumnName() throws {
+//        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+//        defer { try! conn.close().wait() }
+//
+//        let rows = try conn.query("SELECT 1 as foo, 2 as foo").wait()
+//        var i = 0
+//        for column in rows[0].columns {
+//            XCTAssertEqual(column.name, "foo")
+//            i += column.data.integer!
+//        }
+//        XCTAssertEqual(i, 3)
+//        XCTAssertEqual(rows[0].column("foo")?.integer, 1)
+//        XCTAssertEqual(rows[0].columns.filter { $0.name == "foo" }[1].data.integer, 2)
+//    }
 
     var threadPool: NIOThreadPool!
     var eventLoopGroup: EventLoopGroup!


### PR DESCRIPTION
Allows for a boolean field to be stored as string.

```swift
.field("is_true", .string, .required)
```
Additionally it is now its separate type, together with the other types, instead of referring to an anonymous int 
for a return, which makes It cleaner.

Before:
If the field type of a presumed boolean is set to string. it results in below error msg

```
typeMismatch(Swift.Bool, Swift.DecodingError.Context(codingPath: [], debugDescription: "Could not initialize Bool from \"0\".", underlyingError: nil))
```