### PR TITLE
Adds support for datetime string formats

### DIFF
--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -123,6 +123,12 @@ extension Date: SQLiteDataConvertible {
             value = v
         case .integer(let v):
             value = Double(v)
+        case .text(let v):
+            guard let d = dateTimeFormatter.date(from: v) ?? dateFormatter.date(from: v) else {
+                return nil
+            }
+            self = d
+            return
         default:
             return nil
         }
@@ -136,3 +142,26 @@ extension Date: SQLiteDataConvertible {
         return .float(timeIntervalSince1970)
     }
 }
+
+/// Matches dates from the `datetime()` function
+let dateTimeFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [
+        .withFullDate,
+        .withDashSeparatorInDate,
+        .withSpaceBetweenDateAndTime,
+        .withTime,
+        .withColonSeparatorInTime
+    ]
+    return formatter
+}()
+
+/// Matches dates from the `date()` function
+let dateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [
+        .withFullDate,
+        .withDashSeparatorInDate
+    ]
+    return formatter
+}()

--- a/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
+++ b/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
@@ -23,6 +23,26 @@ final class SQLiteNIOTests: XCTestCase {
         print(rows)
     }
 
+    func testDateFormat() throws {
+        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+        
+        XCTAssertEqual(Date(sqliteData: .text("2023-03-10"))?.timeIntervalSince1970, 1678406400)
+        
+        let rows = try conn.query("SELECT CURRENT_DATE").wait()
+        XCTAssertNotNil(Date(sqliteData: rows[0].column("CURRENT_DATE")!))
+    }
+    
+    func testDateTimeFormat() throws {
+        let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
+        defer { try! conn.close().wait() }
+        
+        XCTAssertEqual(Date(sqliteData: .text("2023-03-10 23:54:27"))?.timeIntervalSince1970, 1678492467)
+        
+        let rows = try conn.query("SELECT CURRENT_TIMESTAMP").wait()
+        XCTAssertNotNil(Date(sqliteData: rows[0].column("CURRENT_TIMESTAMP")!))
+    }
+    
     func testTimestampStorage() throws {
         let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()
         defer { try! conn.close().wait() }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Previously, dates were only interpreted from `Double` or `Int` SQLite representations, which caused issues with decoding values of `CURRENT_DATE` and `CURRENT_TIMESTAMP`, which output formatted strings. This PR adds support to interpret dates from strings, matching the formats output by the `date()` and `datetime()` [SQLite functions](https://www.sqlite.org/lang_datefunc.html), which includes the `CURRENT_DATE` and `CURRENT_TIMESTAMP` constants.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
