### PR TITLE
fix: No longer fatal errors on inactive thread pool

### DIFF
--- a/Sources/SQLiteNIO/SQLiteConnection.swift
+++ b/Sources/SQLiteNIO/SQLiteConnection.swift
@@ -98,8 +98,6 @@ public final class SQLiteConnection: SQLiteDatabase {
             path = file
         }
 
-        let promise = eventLoop.makePromise(of: SQLiteConnection.self)
-
         return threadPool.runIfActive(eventLoop: eventLoop) {
             var handle: OpaquePointer?
             let options = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_URI
@@ -112,13 +110,11 @@ public final class SQLiteConnection: SQLiteDatabase {
                     on: eventLoop
                 )
                 logger.debug("Connected to sqlite db: \(path)")
-                return promise.succeed(connection)
+                return connection
             } else {
                 logger.error("Failed to connect to sqlite db: \(path)")
-                return promise.fail(SQLiteError(reason: .cantOpen, message: "Cannot open SQLite database: \(storage)"))
+                throw SQLiteError(reason: .cantOpen, message: "Cannot open SQLite database: \(storage)")
             }
-        }.flatMap {
-            promise.futureResult
         }
     }
 

--- a/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
+++ b/Tests/SQLiteNIOTests/SQLiteNIOTests.swift
@@ -14,6 +14,13 @@ final class SQLiteNIOTests: XCTestCase {
         let compileOptions = try conn.query("PRAGMA compile_options;").wait()
         print(compileOptions)
     }
+    
+    func testConnectionClosedThreadPool() throws {
+        let threadPool = NIOThreadPool(numberOfThreads: 1)
+        try threadPool.syncShutdownGracefully()
+        // This should error, but not create a leaking promise fatal error
+        XCTAssertThrowsError(try SQLiteConnection.open(storage: .memory, threadPool: threadPool, on: self.eventLoop).wait())
+    }
 
     func testZeroLengthBlob() throws {
         let conn = try SQLiteConnection.open(storage: .memory, threadPool: self.threadPool, on: self.eventLoop).wait()


### PR DESCRIPTION
Previously, trying to open a connection on an inactive thread pool would throw `Fatal error: leaking promise created at (file: "SQLiteNIO/SQLiteConnection.swift", line: 101)`. This was because the promise created on line 101 of SQLiteConnection.swift would not be succeeded or failed when the `runIfActive` was called on an inactive thread pool. To resolve this, we avoid creating a new `Promise` altogether, just using the one that `runIfActive` provides.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
