### PR TITLE
fix: Corrects possible leaking promise in `query`

### DIFF
--- a/.api-breakage/allowlist-branch-fix/remove-leaking-promise.txt
+++ b/.api-breakage/allowlist-branch-fix/remove-leaking-promise.txt
@@ -1,0 +1,4 @@
+API breakage: func SQLiteDatabase.query(_:_:logger:_:) is now with @preconcurrency
+API breakage: func SQLiteDatabase.withConnection(_:) is now with @preconcurrency
+API breakage: func SQLiteConnection.withConnection(_:) is now with @preconcurrency
+API breakage: func SQLiteConnection.query(_:_:logger:_:) is now with @preconcurrency

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   dependents-check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    container: swift:5.7-jammy
+    container: swift:5.8-jammy
     steps:
       - name: Check out package
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Similar to https://github.com/vapor/sqlite-nio/pull/44, this removes a leaking promise when calling `query` on an inactive thread pool.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
