### PR TITLE
Embed sqlite amalgamation v3.46.0 source code

### DIFF
--- a/Sources/CSQLite/version.txt
+++ b/Sources/CSQLite/version.txt
@@ -1,2 +1,2 @@
-// This directory is generated from SQLite sources downloaded from https://sqlite.org/2024/sqlite-amalgamation-3450300.zip
-3.45.3
+// This directory is generated from SQLite sources downloaded from https://sqlite.org/2024/sqlite-amalgamation-3460000.zip
+3.46.0

--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -144,7 +144,10 @@ extension Date: SQLiteDataConvertible {
 }
 
 /// Matches dates from the `datetime()` function
-let dateTimeFormatter: ISO8601DateFormatter = {
+///
+/// > Note: Because `ISO8601DateFormatter` isn't `Sendable`, we have to do the MUCH less efficient thing of creating
+/// > a new formatter every time we want to use it instead of just caching one :(
+var dateTimeFormatter: ISO8601DateFormatter {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [
         .withFullDate,
@@ -154,14 +157,17 @@ let dateTimeFormatter: ISO8601DateFormatter = {
         .withColonSeparatorInTime
     ]
     return formatter
-}()
+}
 
 /// Matches dates from the `date()` function
-let dateFormatter: ISO8601DateFormatter = {
+///
+/// > Note: Because `ISO8601DateFormatter` isn't `Sendable`, we have to do the MUCH less efficient thing of creating
+/// > a new formatter every time we want to use it instead of just caching one :(
+var dateFormatter: ISO8601DateFormatter {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [
         .withFullDate,
         .withDashSeparatorInDate
     ]
     return formatter
-}()
+}


### PR DESCRIPTION
Update embedded SQLite from 3.45.3 to 3.46.0 ([SQLite release notes](https://sqlite.org/releaselog/3_46_0.html)).

Also fixes `Sendable` warnings in `SQLiteDataConvertible` (incidentally solving a real thread-safety issue in the process).