### PR TITLE
Fix date rounding precision for dates stored as text

### DIFF
--- a/Sources/SQLiteNIO/SQLiteDataConvertible.swift
+++ b/Sources/SQLiteNIO/SQLiteDataConvertible.swift
@@ -127,8 +127,7 @@ extension Date: SQLiteDataConvertible {
             guard let d = dateTimeFormatter.date(from: v) ?? dateFormatter.date(from: v) else {
                 return nil
             }
-            self = d
-            return
+            value = d.timeIntervalSince1970
         default:
             return nil
         }


### PR DESCRIPTION
Dates stored as text were not respecting the microsecond precision rounding that numeric types provided.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
