### PR TITLE
Embed sqlite amalgamation 3.49.1 source code

### DIFF
--- a/Sources/CSQLite/include/sqlite_nio_sqlite3.h
+++ b/Sources/CSQLite/include/sqlite_nio_sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite_nio_sqlite3_libversion_number()], [sqlite_nio_sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.49.0"
-#define SQLITE_VERSION_NUMBER 3049000
-#define SQLITE_SOURCE_ID      "2025-02-06 11:55:18 4a7dd425dc2a0e5082a9049c9b4a9d4f199a71583d014c24b4cfe276c5a77cde"
+#define SQLITE_VERSION        "3.49.1"
+#define SQLITE_VERSION_NUMBER 3049001
+#define SQLITE_SOURCE_ID      "2025-02-18 13:38:58 873d4e274b4988d260ba8354a9718324a1c26187a4ab4c1cc0227c03d0f10e70"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/Sources/CSQLite/version.txt
+++ b/Sources/CSQLite/version.txt
@@ -1,2 +1,2 @@
-// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3490000.zip
-3.49.0
+// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3490100.zip
+3.49.1


### PR DESCRIPTION
Update embedded SQLite from 3.49.0 to 3.49.1 ([SQLite release notes](https://sqlite.org/releaselog/3_49_1.html)).