### PR TITLE
Update Swift version and other minor items

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
     container: swift:6.1-noble
+    steps:
       - name: Check out package
         uses: actions/checkout@v4
         with: { path: 'sqlite-nio' }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,19 +5,15 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
-
 env:
   LOG_LEVEL: info
-  SWIFT_DETERMINISTIC_HASHING: 1
 
 jobs:
-
   # Make sure downstream dependents still work
   dependents-check:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest
-    container: swift:5.10-jammy
-    steps:
+    container: swift:6.1-noble
       - name: Check out package
         uses: actions/checkout@v4
         with: { path: 'sqlite-nio' }
@@ -39,3 +35,6 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@main
     secrets: inherit
+    with:
+      with_musl: true
+      with_android: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(

--- a/Plugins/VendorSQLite/001-warnings-and-data-race.patch
+++ b/Plugins/VendorSQLite/001-warnings-and-data-race.patch
@@ -1,11 +1,12 @@
 --- a/sqlite3.c
 +++ b/sqlite3.c
-@@ -1,2 +1,4 @@
+@@ -1,3 +1,5 @@
 +#pragma clang diagnostic ignored "-Wambiguous-macro"
 +#pragma clang diagnostic ignored "-Wshorten-64-to-32"
  /******************************************************************************
  ** This file is an amalgamation of many separate C source files from SQLite
-@@ -165427,7 +165429,10 @@ SQLITE_API sqlite_int64 sqlite3_last_insert_rowid(sqlite3 *db){
+ ** version 3.49.1.  By combining all the individual C code files into this
+@@ -182634,7 +182636,10 @@ SQLITE_API sqlite_int64 sqlite3_last_ins
      return 0;
    }
  #endif
@@ -15,6 +16,5 @@
 +  sqlite3_mutex_leave(db->mutex);
 +  return lastRowId;
  }
- /*
- ** Set the value returned by the sqlite_nio_sqlite3_last_insert_rowid() API function.
 
+ /*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/vapor/sqlite-nio/assets/1130717/84529505-7534-456f-a065-c06cc84f3c0d">
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/vapor/sqlite-nio/assets/1130717/a839372c-5f79-4e59-8cf7-db44af8f20a9">
-  <img src="https://github.com/vapor/sqlite-nio/assets/1130717/a839372c-5f79-4e59-8cf7-db44af8f20a9" height="96" alt="SQLiteNIO">
-</picture> 
+<img src="https://design.vapor.codes/images/vapor-sqlitenio.svg" height="96" alt="SQLiteNIO">
 <br>
 <br>
 <a href="https://docs.vapor.codes/4.0/"><img src="https://design.vapor.codes/images/readthedocs.svg" alt="Documentation"></a>
@@ -11,12 +7,12 @@
 <a href="LICENSE"><img src="https://design.vapor.codes/images/mitlicense.svg" alt="MIT License"></a>
 <a href="https://github.com/vapor/sqlite-nio/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/vapor/sqlite-nio/test.yml?event=push&style=plastic&logo=github&label=tests&logoColor=%23ccc" alt="Continuous Integration"></a>
 <a href="https://codecov.io/github/vapor/sqlite-nio"><img src="https://img.shields.io/codecov/c/github/vapor/sqlite-nio?style=plastic&logo=codecov&label=codecov"></a>
-<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift58up.svg" alt="Swift 5.8+"></a>
+<a href="https://swift.org"><img src="https://design.vapor.codes/images/swift510up.svg" alt="Swift 5.10+"></a>
 </p>
 
 <br>
 
-🐬 Non-blocking, event-driven Swift client for [SQLite](https://sqlite.org) built on [SwiftNIO](https://github.com/apple/swift-nio).
+🪶 Non-blocking, event-driven Swift client for [SQLite](https://sqlite.org) built on [SwiftNIO](https://github.com/apple/swift-nio).
 
 ## Using SQLiteNIO
 

--- a/Sources/SQLiteNIO/Docs.docc/Documentation.md
+++ b/Sources/SQLiteNIO/Docs.docc/Documentation.md
@@ -4,13 +4,23 @@
     @TitleHeading(Package)
 }
 
-🪶 Non-blocking, event-driven Swift client for SQLite with embedded `libsqlite`.
+🪶 Non-blocking, event-driven Swift client for [SQLite](https://sqlite.org) built on [SwiftNIO](https://github.com/apple/swift-nio).
 
-## Supported Versions
+## Using SQLiteNIO
 
-This package is compatible with all platforms supported by [SwiftNIO 2.x](https://github.com/apple/swift-nio/). It has been specifically tested on the following platforms:
+Use standard SwiftPM syntax to include SQLiteNIO as a dependency in your `Package.swift` file:
 
-- Ubuntu 20.04 ("Focal") and 22.04 ("Jammy")
-- Amazon Linux 2
-- macOS 10.15 and later
-- iOS 13 and later
+```swift
+dependencies: [
+    .package(url: "https://github.com/vapor/sqlite-nio.git", from: "1.0.0")
+]
+```
+
+### Supported Platforms
+
+SQLiteNIO supports all platforms on which NIO itself works. At the time of this writing, these include:
+
+- Ubuntu 20.04+
+- macOS 10.15+
+- iOS 13+
+- tvOS 13+ and watchOS 7+ (experimental)


### PR DESCRIPTION
Detailed list of changes:

- The required minimum Swift version is now 5.10. This is the only even nominally functional item in this changeset and is solely responsible for the version bump.
- The README now uses the "feather" ('SQLite') instead of "dolphin" ('MySQL') emoji, and shows the correct Swift version badge. It also uses the new version of the banner image.
- The front page for the API docs now shows the same up to date information as the README.
- The patch for the `lastRowId` data race in `libsqlite` has been updated to match the current embedded version so that its line numbers are no longer offset by about 25,000 lines.
- The vendoring plugin now uses `PackagePlugin.Diagnostics.progress(_:)` instead of just calling `print()`, which produces very slightly nicer output for the two or three people who'll ever see it.