### PR TITLE
Embed sqlite amalgamation 3.49.2 source code

### DIFF
--- a/Plugins/VendorSQLite/001-warnings-and-data-race.patch
+++ b/Plugins/VendorSQLite/001-warnings-and-data-race.patch
@@ -1,11 +1,10 @@
 --- a/sqlite3.c
 +++ b/sqlite3.c
-@@ -1,3 +1,5 @@
+@@ -1,2 +1,4 @@
 +#pragma clang diagnostic ignored "-Wambiguous-macro"
 +#pragma clang diagnostic ignored "-Wshorten-64-to-32"
  /******************************************************************************
  ** This file is an amalgamation of many separate C source files from SQLite
- ** version 3.49.1.  By combining all the individual C code files into this
 @@ -182634,7 +182636,10 @@ SQLITE_API sqlite_int64 sqlite3_last_ins
      return 0;
    }

--- a/Sources/CSQLite/include/sqlite_nio_sqlite3.h
+++ b/Sources/CSQLite/include/sqlite_nio_sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite_nio_sqlite3_libversion_number()], [sqlite_nio_sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.49.1"
-#define SQLITE_VERSION_NUMBER 3049001
-#define SQLITE_SOURCE_ID      "2025-02-18 13:38:58 873d4e274b4988d260ba8354a9718324a1c26187a4ab4c1cc0227c03d0f10e70"
+#define SQLITE_VERSION        "3.49.2"
+#define SQLITE_VERSION_NUMBER 3049002
+#define SQLITE_SOURCE_ID      "2025-05-07 10:39:52 17144570b0d96ae63cd6f3edca39e27ebd74925252bbaf6723bcb2f6b4861fb1"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/Sources/CSQLite/version.txt
+++ b/Sources/CSQLite/version.txt
@@ -1,2 +1,2 @@
-// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3490100.zip
-3.49.1
+// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3490200.zip
+3.49.2


### PR DESCRIPTION
Update embedded SQLite from 3.49.1 to 3.49.2 ([SQLite release notes](https://sqlite.org/releaselog/3_49_2.html)).