### PR TITLE
Embed sqlite amalgamation 3.50.1 source code

### DIFF
--- a/Sources/CSQLite/include/sqlite_nio_sqlite3.h
+++ b/Sources/CSQLite/include/sqlite_nio_sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite_nio_sqlite3_libversion_number()], [sqlite_nio_sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.50.0"
-#define SQLITE_VERSION_NUMBER 3050000
-#define SQLITE_SOURCE_ID      "2025-05-29 14:26:00 dfc790f998f450d9c35e3ba1c8c89c17466cb559f87b0239e4aab9d34e28f742"
+#define SQLITE_VERSION        "3.50.1"
+#define SQLITE_VERSION_NUMBER 3050001
+#define SQLITE_SOURCE_ID      "2025-06-06 14:52:32 b77dc5e0f596d2140d9ac682b2893ff65d3a4140aa86067a3efebe29dc914c95"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/Sources/CSQLite/version.txt
+++ b/Sources/CSQLite/version.txt
@@ -1,2 +1,2 @@
-// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3500000.zip
-3.50.0
+// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3500100.zip
+3.50.1


### PR DESCRIPTION
Update embedded SQLite from 3.50.0 to 3.50.1 ([SQLite release notes](https://sqlite.org/releaselog/3_50_1.html)).