### PR TITLE
Embed sqlite amalgamation 3.51.3 source code

### DIFF
--- a/Sources/VaporCSQLite/include/sqlite_nio_sqlite3.h
+++ b/Sources/VaporCSQLite/include/sqlite_nio_sqlite3.h
@@ -146,12 +146,12 @@ extern "C" {
 ** [sqlite_nio_sqlite3_libversion_number()], [sqlite_nio_sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.51.1"
-#define SQLITE_VERSION_NUMBER 3051001
-#define SQLITE_SOURCE_ID      "2025-11-28 17:28:25 281fc0e9afc38674b9b0991943b9e9d1e64c6cbdb133d35f6f5c87ff6af38a88"
+#define SQLITE_VERSION        "3.51.3"
+#define SQLITE_VERSION_NUMBER 3051003
+#define SQLITE_SOURCE_ID      "2026-03-13 10:38:09 737ae4a34738ffa0c3ff7f9bb18df914dd1cad163f28fd6b6e114a344fe6d618"
 #define SQLITE_SCM_BRANCH     "branch-3.51"
-#define SQLITE_SCM_TAGS       "release version-3.51.1"
-#define SQLITE_SCM_DATETIME   "2025-11-28T17:28:25.933Z"
+#define SQLITE_SCM_TAGS       "release version-3.51.3"
+#define SQLITE_SCM_DATETIME   "2026-03-13T10:38:09.694Z"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/Sources/VaporCSQLite/version.txt
+++ b/Sources/VaporCSQLite/version.txt
@@ -1,2 +1,2 @@
-// This directory is generated from SQLite sources downloaded from https://sqlite.org/2025/sqlite-amalgamation-3510100.zip
-3.51.1
+// This directory is generated from SQLite sources downloaded from https://sqlite.org/2026/sqlite-amalgamation-3510300.zip
+3.51.3


### PR DESCRIPTION
**These changes are now available in [1.12.6](https://github.com/vapor/sqlite-nio/releases/tag/1.12.6)**


Update embedded SQLite from 3.51.1 to 3.51.3 ([SQLite release notes](https://sqlite.org/releaselog/3_51_3.html)).